### PR TITLE
192 Word of the Day

### DIFF
--- a/ParrotIos/Features/Exercise/ViewModels/AttemptView-ViewModel.swift
+++ b/ParrotIos/Features/Exercise/ViewModels/AttemptView-ViewModel.swift
@@ -18,6 +18,7 @@ extension AttemptView {
         private(set) var isRecording: Bool = false
         private(set) var isPlaying: Bool = false
         private(set) var isLoading: Bool = false
+        private(set) var disableRecording: Bool = false
         private(set) var errorMessage: String?
         
         private(set) var exerciseId: Int
@@ -64,6 +65,10 @@ extension AttemptView {
         func startRecording() {
             isRecording = true
             audioRecorder.startRecording()
+            disableRecording = true
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                self.disableRecording = false  // Re-enable after 1 second
+            }
         }
         
         func stopRecording() async {

--- a/ParrotIos/Features/Exercise/Views/AttemptView.swift
+++ b/ParrotIos/Features/Exercise/Views/AttemptView.swift
@@ -64,6 +64,7 @@ struct AttemptView: View {
                             .background(viewModel.isRecording ? Color.red.opacity(0.8) : Color.blue)
                             .clipShape(Circle())
                     }
+                    .disabled(viewModel.disableRecording)
                     
                     Spacer()
                     

--- a/ParrotIos/Features/Exercise/Views/AttemptView.swift
+++ b/ParrotIos/Features/Exercise/Views/AttemptView.swift
@@ -10,91 +10,31 @@ import SwiftUI
 struct AttemptView: View {
     @State private var viewModel: ViewModel
     @State private var finish: Bool = false
-    
+
     @Environment(\.dismiss) private var dismiss
-    
+
     init(exerciseId: Int) {
         self.viewModel = ViewModel(exerciseId: exerciseId)
-    }
-    
-    private func wordView(word: Word) -> some View {
-        VStack {
-            Text(word.text).font(.largeTitle)
-            Text(word.phonemes
-                .compactMap { $0.respelling }
-                .joined(separator: "."))
-            .font(.title)
-            .foregroundColor(Color.gray)
-        }
-    }
-    
-    private func feedbackView(word: Word, goldPhonemes: [Phoneme], recordingPhonemes: [Phoneme], xp_gain: Int) -> some View {
-        VStack {
-            Text(word.text).font(.largeTitle)
-            Text(goldPhonemes
-                .compactMap { $0.respelling }
-                .joined(separator: "."))
-            .font(.title)
-            .foregroundColor(.green)
-            Text(recordingPhonemes
-                .compactMap { $0.respelling }
-                .joined(separator: "."))
-            .font(.title)
-            .foregroundColor(.red)
-            HStack(spacing: 4) {
-                Text("\(xp_gain) XP")
-                    .font(.headline)
-                    .foregroundColor(.red)
-                Text("🔥")
-            }
-        }
-    }
-    
-    private func scoreView(score: Int) -> some View {
-        VStack {
-            Text("\(score)%")
-                .font(.headline)
-                .multilineTextAlignment(.center)
-                .padding(.bottom, 8)
-            
-            ProgressView(value: Float(score) / 100.0)
-                .padding(.horizontal, 128)
-        }
-    }
-    
-    private var loadingView: some View {
-        ProgressView("Loading...")
-            .scaleEffect(1.5, anchor: .center)
-            .padding()
-    }
-    
-    private func errorView(errorMessage: String) -> some View {
-        VStack {
-            Text(errorMessage)
-                .foregroundColor(.red)
-                .multilineTextAlignment(.center)
-                .padding()
-        }
     }
     
     var body: some View {
         VStack {
             if viewModel.isLoading {
-                loadingView
+                UtilComponents.loadingView
             } else if let errorMessage = viewModel.errorMessage {
-                errorView(errorMessage: errorMessage)
+                UtilComponents.errorView(errorMessage: errorMessage)
             } else if let exercise = viewModel.exercise {
                 Spacer()
                 VStack(spacing: 32) {
                     if let score = viewModel.score {
-                        scoreView(score: score)
-                        feedbackView(
+                        AttemptComponents.scoreView(score: score)
+                        AttemptComponents.feedbackView(
                             word: exercise.word,
                             goldPhonemes: exercise.word.phonemes,
                             recordingPhonemes: viewModel.recording_phonemes!,
                             xp_gain: viewModel.xp_gain!)
                     } else {
-                        wordView(word: exercise.word)
+                        AttemptComponents.wordView(word: exercise.word)
                     }
                 }
                 Spacer()

--- a/ParrotIos/Features/Nav/Views/NavigationView.swift
+++ b/ParrotIos/Features/Nav/Views/NavigationView.swift
@@ -9,24 +9,30 @@ import SwiftUI
 
 // Main Navigation View
 struct NavigationView: View {
+    
+    @State private var selection: Int = 1
+    
     var body: some View {
-        TabView {
+        TabView(selection: $selection) {
             NavigationStack {
                 CurriculumView()
             }
                 .tabItem {
                     Label("Learn", systemImage: "text.book.closed")
                 }
-            
+                .tag(0)
+
             WordOfTheDayView()
                 .tabItem {
                     Label("Word of the Day", systemImage: "calendar.badge.clock")
                 }
-            
+                .tag(1)
+
             LeaderboardView()
                 .tabItem {
                     Label("Leaderboard", systemImage: "medal")
                 }
+                .tag(2)
         }
     }
 }

--- a/ParrotIos/Features/Nav/Views/NavigationView.swift
+++ b/ParrotIos/Features/Nav/Views/NavigationView.swift
@@ -18,6 +18,11 @@ struct NavigationView: View {
                     Label("Learn", systemImage: "text.book.closed")
                 }
             
+            WordOfTheDayView()
+                .tabItem {
+                    Label("Word of the Day", systemImage: "calendar.badge.clock")
+                }
+            
             LeaderboardView()
                 .tabItem {
                     Label("Leaderboard", systemImage: "medal")

--- a/ParrotIos/Features/Unit/Views/CurriculumView.swift
+++ b/ParrotIos/Features/Unit/Views/CurriculumView.swift
@@ -10,28 +10,13 @@ import SwiftUI
 struct CurriculumView: View {
     let viewModel = ViewModel()
     
-    private func errorView(errorMessage: String) -> some View {
-        VStack {
-            Text(errorMessage)
-                .foregroundColor(.red)
-                .multilineTextAlignment(.center)
-                .padding()
-        }
-    }
-    
-    private var loadingView: some View {
-        ProgressView("Loading...")
-            .scaleEffect(1.5, anchor: .center)
-            .padding()
-    }
-    
     var body: some View {
         ScrollView {
             VStack {
                 if viewModel.isLoading {
-                    loadingView
+                    UtilComponents.loadingView
                 } else if let error = viewModel.errorMessage {
-                    errorView(errorMessage: error)
+                    UtilComponents.errorView(errorMessage: error)
                 } else {
                     ForEach(viewModel.curriculum!.units) { unit in
                         VStack {

--- a/ParrotIos/Features/WordOfTheDay/ViewModels/WordOfTheDayView-ViewModel.swift
+++ b/ParrotIos/Features/WordOfTheDay/ViewModels/WordOfTheDayView-ViewModel.swift
@@ -13,7 +13,6 @@ extension WordOfTheDayView {
     @Observable
     class ViewModel {
         private let audioRecorder: AudioRecorderProtocol
-        private let audioPlayer: AudioPlayerProtocol
         private let parrotApi: ParrotApiServiceProtocol
 
         private(set) var isRecording: Bool = false
@@ -26,9 +25,8 @@ extension WordOfTheDayView {
         private(set) var recording_phonemes: [Phoneme]?
         private(set) var xp_gain: Int?
 
-        init(audioRecoder: AudioRecorderProtocol = AudioRecorder(), audioPlayer: AudioPlayerProtocol = AudioPlayer(), parrotApi: ParrotApiServiceProtocol = ParrotApiService(webService: WebService(), authService: AuthService())) {
+        init(audioRecoder: AudioRecorderProtocol = AudioRecorder(), parrotApi: ParrotApiServiceProtocol = ParrotApiService(webService: WebService(), authService: AuthService())) {
             self.audioRecorder = audioRecoder
-            self.audioPlayer = audioPlayer
             self.parrotApi = parrotApi
         }
 
@@ -78,14 +76,6 @@ extension WordOfTheDayView {
             } else {
                 startRecording()
             }
-        }
-
-        func playWord() {
-            let word: String = self.word?.text ?? ""
-            isPlaying = true
-            // Rate currently set so that the automated voice speaks slowly
-            audioPlayer.play(word: word, rate: 0.5)
-            isPlaying = false
         }
     }
 }

--- a/ParrotIos/Features/WordOfTheDay/ViewModels/WordOfTheDayView-ViewModel.swift
+++ b/ParrotIos/Features/WordOfTheDay/ViewModels/WordOfTheDayView-ViewModel.swift
@@ -58,8 +58,18 @@ extension WordOfTheDayView {
         }
 
         func uploadRecording(recordingURL: URL) async {
+            isLoading = true
             errorMessage = nil
-            // TODO: upload to word of the day post endpoint
+
+            do {
+                let attemptResponse = try await parrotApi.postWordOfTheDayAttempt(recordingURL: recordingURL)
+                self.score = attemptResponse.score
+                self.recording_phonemes = attemptResponse.recording_phonemes
+                self.xp_gain = attemptResponse.xp_gain
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+            isLoading = false
         }
 
         func toggleRecording() async {

--- a/ParrotIos/Features/WordOfTheDay/ViewModels/WordOfTheDayView-ViewModel.swift
+++ b/ParrotIos/Features/WordOfTheDay/ViewModels/WordOfTheDayView-ViewModel.swift
@@ -1,0 +1,17 @@
+//
+//  WordOfTheDayView-ViewModel.swift
+//  ParrotIos
+//
+//  Created by Henry Yu on 20/2/2025.
+//
+
+import Foundation
+import SwiftUI
+
+extension WordOfTheDayView {
+    
+    @Observable
+    class ViewModel {
+        
+    }
+}

--- a/ParrotIos/Features/WordOfTheDay/ViewModels/WordOfTheDayView-ViewModel.swift
+++ b/ParrotIos/Features/WordOfTheDay/ViewModels/WordOfTheDayView-ViewModel.swift
@@ -9,9 +9,73 @@ import Foundation
 import SwiftUI
 
 extension WordOfTheDayView {
-    
+
     @Observable
     class ViewModel {
-        
+        private let audioRecorder: AudioRecorderProtocol
+        private let audioPlayer: AudioPlayerProtocol
+        private let parrotApi: ParrotApiServiceProtocol
+
+        private(set) var isRecording: Bool = false
+        private(set) var isPlaying: Bool = false
+        private(set) var isLoading: Bool = false
+        private(set) var errorMessage: String?
+
+        private(set) var word: Word?
+        private(set) var score: Int?
+        private(set) var recording_phonemes: [Phoneme]?
+        private(set) var xp_gain: Int?
+
+        init(audioRecoder: AudioRecorderProtocol = AudioRecorder(), audioPlayer: AudioPlayerProtocol = AudioPlayer(), parrotApi: ParrotApiServiceProtocol = ParrotApiService(webService: WebService(), authService: AuthService())) {
+            self.audioRecorder = audioRecoder
+            self.audioPlayer = audioPlayer
+            self.parrotApi = parrotApi
+        }
+
+        func loadWordOfTheDay() async {
+            isLoading = true
+            errorMessage = nil
+            score = nil
+            recording_phonemes = nil
+            xp_gain = nil
+            do {
+                self.word = try await parrotApi.getWordOfTheDay()
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+            isLoading = false
+        }
+
+        func startRecording() {
+            isRecording = true
+            audioRecorder.startRecording()
+        }
+
+        func stopRecording() async {
+            isRecording = false
+            audioRecorder.stopRecording()
+            await uploadRecording(recordingURL: audioRecorder.getRecordingURL())
+        }
+
+        func uploadRecording(recordingURL: URL) async {
+            errorMessage = nil
+            // TODO: upload to word of the day post endpoint
+        }
+
+        func toggleRecording() async {
+            if isRecording {
+                await stopRecording()
+            } else {
+                startRecording()
+            }
+        }
+
+        func playWord() {
+            let word: String = self.word?.text ?? ""
+            isPlaying = true
+            // Rate currently set so that the automated voice speaks slowly
+            audioPlayer.play(word: word, rate: 0.5)
+            isPlaying = false
+        }
     }
 }

--- a/ParrotIos/Features/WordOfTheDay/Views/WordOfTheDayView.swift
+++ b/ParrotIos/Features/WordOfTheDay/Views/WordOfTheDayView.swift
@@ -1,0 +1,21 @@
+//
+//  WordOfTheDayView.swift
+//  ParrotIos
+//
+//  Created by Henry Yu on 20/2/2025.
+//
+
+import SwiftUI
+
+struct WordOfTheDayView: View {
+    
+    @State private var viewModel: ViewModel
+    
+    init(viewModel: ViewModel = ViewModel()) {
+        self.viewModel = viewModel
+    }
+    
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}

--- a/ParrotIos/Features/WordOfTheDay/Views/WordOfTheDayView.swift
+++ b/ParrotIos/Features/WordOfTheDay/Views/WordOfTheDayView.swift
@@ -22,7 +22,20 @@ struct WordOfTheDayView: View {
             } else if let errorMessage = viewModel.errorMessage {
                 UtilComponents.errorView(errorMessage: errorMessage)
             } else if let word = viewModel.word {
+                Text("🗓️ Word of the Day")
+                    .font(.title)
+                    .bold()
+                    .padding(.top, 20)
+                Text(Date.now.formatted(date: .long, time: .omitted))
+                    .font(.subheadline)
+                    .foregroundColor(.gray)
+                    .padding(.bottom, 20)
+                Text("No audio demo for you, challenge yourself!")
+                    .font(.caption)
+                    .foregroundColor(.gray)
+
                 Spacer()
+
                 VStack(spacing: 32) {
                     if let score = viewModel.score {
                         AttemptComponents.scoreView(score: score)
@@ -38,32 +51,19 @@ struct WordOfTheDayView: View {
 
                 Spacer()
 
-                HStack {
-                    Button(action: { viewModel.playWord() }) {
-                        Image(systemName: "speaker.wave.3")
-                            .font(.title3)
-                            .foregroundColor(.white)
-                            .frame(width: 50, height: 50)
-                            .background(viewModel.isPlaying ? Color.red.opacity(0.8) : Color.blue)
-                            .clipShape(Circle())
+                Button(action: {
+                    Task {
+                        await viewModel.toggleRecording()
                     }
-
-                    Spacer()
-
-                    Button(action: {
-                        Task {
-                            await viewModel.toggleRecording()
-                        }
-                    }) {
-                        Image(systemName: "mic")
-                            .font(.largeTitle)
-                            .foregroundColor(.white)
-                            .frame(width: 80, height: 80)
-                            .background(viewModel.isRecording ? Color.red.opacity(0.8) : Color.blue)
-                            .clipShape(Circle())
-                    }
+                }) {
+                    Image(systemName: "mic")
+                        .font(.largeTitle)
+                        .foregroundColor(.white)
+                        .frame(width: 80, height: 80)
+                        .background(viewModel.isRecording ? Color.red.opacity(0.8) : Color.blue)
+                        .clipShape(Circle())
                 }
-                .padding(.horizontal, 50)
+                .padding(.bottom, 20)
             }
         }
         .task {

--- a/ParrotIos/Features/WordOfTheDay/Views/WordOfTheDayView.swift
+++ b/ParrotIos/Features/WordOfTheDay/Views/WordOfTheDayView.swift
@@ -8,14 +8,66 @@
 import SwiftUI
 
 struct WordOfTheDayView: View {
-    
+
     @State private var viewModel: ViewModel
-    
+
     init(viewModel: ViewModel = ViewModel()) {
         self.viewModel = viewModel
     }
-    
+
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        VStack {
+            if viewModel.isLoading {
+                UtilComponents.loadingView
+            } else if let errorMessage = viewModel.errorMessage {
+                UtilComponents.errorView(errorMessage: errorMessage)
+            } else if let word = viewModel.word {
+                Spacer()
+                VStack(spacing: 32) {
+                    if let score = viewModel.score {
+                        AttemptComponents.scoreView(score: score)
+                        AttemptComponents.feedbackView(
+                            word: word,
+                            goldPhonemes: word.phonemes,
+                            recordingPhonemes: viewModel.recording_phonemes!,
+                            xp_gain: viewModel.xp_gain!)
+                    } else {
+                        AttemptComponents.wordView(word: word)
+                    }
+                }
+
+                Spacer()
+
+                HStack {
+                    Button(action: { viewModel.playWord() }) {
+                        Image(systemName: "speaker.wave.3")
+                            .font(.title3)
+                            .foregroundColor(.white)
+                            .frame(width: 50, height: 50)
+                            .background(viewModel.isPlaying ? Color.red.opacity(0.8) : Color.blue)
+                            .clipShape(Circle())
+                    }
+
+                    Spacer()
+
+                    Button(action: {
+                        Task {
+                            await viewModel.toggleRecording()
+                        }
+                    }) {
+                        Image(systemName: "mic")
+                            .font(.largeTitle)
+                            .foregroundColor(.white)
+                            .frame(width: 80, height: 80)
+                            .background(viewModel.isRecording ? Color.red.opacity(0.8) : Color.blue)
+                            .clipShape(Circle())
+                    }
+                }
+                .padding(.horizontal, 50)
+            }
+        }
+        .task {
+            await viewModel.loadWordOfTheDay()
+        }
     }
 }

--- a/ParrotIos/Services/ParrotApiService.swift
+++ b/ParrotIos/Services/ParrotApiService.swift
@@ -33,9 +33,8 @@ class ParrotApiService: ParrotApiServiceProtocol {
         return try await getData(endpoint: "/leaderboard/global")
     }
     
-    func getRandomWord() async throws -> Word {
-        return try await getData(endpoint: "/random_word")
-        
+    func getWordOfTheDay() async throws -> Word {
+        return try await getData(endpoint: "/word_of_day")
     }
     
     func getCurriculum() async throws -> Curriculum {

--- a/ParrotIos/Services/ParrotApiService.swift
+++ b/ParrotIos/Services/ParrotApiService.swift
@@ -33,10 +33,6 @@ class ParrotApiService: ParrotApiServiceProtocol {
         return try await getData(endpoint: "/leaderboard/global")
     }
     
-    func getWordOfTheDay() async throws -> Word {
-        return try await getData(endpoint: "/word_of_day")
-    }
-    
     func getCurriculum() async throws -> Curriculum {
         return try await getData(endpoint: "/units")
     }
@@ -61,7 +57,28 @@ class ParrotApiService: ParrotApiServiceProtocol {
             
         return response
     }
-    
+
+    func getWordOfTheDay() async throws -> Word {
+        return try await getData(endpoint: "/word_of_day")
+    }
+
+    func postWordOfTheDayAttempt(recordingURL: URL) async throws -> AttemptResponse {
+        guard let accessToken = authService.getAccessToken() else { throw LogoutError.notLoggedIn }
+
+        let audioFile = try Data(contentsOf: recordingURL)
+
+        let formData: [MultiPartFormDataElement] = [
+            MultiPartFormDataElement(name: "audio_file", filename: "recording.wav", contentType: "audio/wav", data: audioFile)
+        ]
+
+        let response: AttemptResponse = try await webService.postMultiPartFormData(
+            data: formData,
+            toURL: baseURL + "/word_of_day",
+            headers: [generateAuthHeader(accessToken: accessToken)])
+
+        return response
+    }
+
     private func generateAuthHeader(accessToken: String) -> HeaderElement {
         return HeaderElement(key: "Authorization", value: "Bearer " + accessToken)
     }

--- a/ParrotIos/Services/Protocols/ParrotApiServiceProtocol.swift
+++ b/ParrotIos/Services/Protocols/ParrotApiServiceProtocol.swift
@@ -11,11 +11,13 @@ protocol ParrotApiServiceProtocol {
     
     func getLeaderboard() async throws -> LeaderboardResponse
     
-    func getWordOfTheDay() async throws -> Word
-    
     func getCurriculum() async throws -> Curriculum
     
     func getExercise(exerciseId: Int) async throws -> Exercise
     
     func postExerciseAttempt(recordingURL: URL, exercise: Exercise) async throws -> AttemptResponse
+
+    func getWordOfTheDay() async throws -> Word
+
+    func postWordOfTheDayAttempt(recordingURL: URL) async throws -> AttemptResponse
 }

--- a/ParrotIos/Services/Protocols/ParrotApiServiceProtocol.swift
+++ b/ParrotIos/Services/Protocols/ParrotApiServiceProtocol.swift
@@ -11,7 +11,7 @@ protocol ParrotApiServiceProtocol {
     
     func getLeaderboard() async throws -> LeaderboardResponse
     
-    func getRandomWord() async throws -> Word
+    func getWordOfTheDay() async throws -> Word
     
     func getCurriculum() async throws -> Curriculum
     

--- a/ParrotIos/ViewComponents/AttemptComponents.swift
+++ b/ParrotIos/ViewComponents/AttemptComponents.swift
@@ -1,0 +1,57 @@
+//
+//  AttemptComponents.swift
+//  ParrotIos
+//
+//  Created by Henry Yu on 20/2/2025.
+//
+
+import Foundation
+import SwiftUI
+
+struct AttemptComponents {
+    
+    public static func wordView(word: Word) -> some View {
+        VStack {
+            Text(word.text).font(.largeTitle)
+            Text(word.phonemes
+                .compactMap { $0.respelling }
+                .joined(separator: "."))
+            .font(.title)
+            .foregroundColor(Color.gray)
+        }
+    }
+    
+    public static func feedbackView(word: Word, goldPhonemes: [Phoneme], recordingPhonemes: [Phoneme], xp_gain: Int) -> some View {
+        VStack {
+            Text(word.text).font(.largeTitle)
+            Text(goldPhonemes
+                .compactMap { $0.respelling }
+                .joined(separator: "."))
+            .font(.title)
+            .foregroundColor(.green)
+            Text(recordingPhonemes
+                .compactMap { $0.respelling }
+                .joined(separator: "."))
+            .font(.title)
+            .foregroundColor(.red)
+            HStack(spacing: 4) {
+                Text("\(xp_gain) XP")
+                    .font(.headline)
+                    .foregroundColor(.red)
+                Text("🔥")
+            }
+        }
+    }
+    
+    public static func scoreView(score: Int) -> some View {
+        VStack {
+            Text("\(score)%")
+                .font(.headline)
+                .multilineTextAlignment(.center)
+                .padding(.bottom, 8)
+            
+            ProgressView(value: Float(score) / 100.0)
+                .padding(.horizontal, 128)
+        }
+    }
+}

--- a/ParrotIos/ViewComponents/UtilComponents.swift
+++ b/ParrotIos/ViewComponents/UtilComponents.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 struct UtilComponents {
 
-    public static let loadingView: some View {
+    public static var loadingView: some View {
         ProgressView("Loading...")
             .scaleEffect(1.5, anchor: .center)
             .padding()

--- a/ParrotIos/ViewComponents/UtilComponents.swift
+++ b/ParrotIos/ViewComponents/UtilComponents.swift
@@ -1,0 +1,27 @@
+//
+//  UtilComponents.swift
+//  ParrotIos
+//
+//  Created by Henry Yu on 20/2/2025.
+//
+
+import Foundation
+import SwiftUI
+
+struct UtilComponents {
+
+    public static let loadingView: some View {
+        ProgressView("Loading...")
+            .scaleEffect(1.5, anchor: .center)
+            .padding()
+    }
+
+    public static func errorView(errorMessage: String) -> some View {
+        VStack {
+            Text(errorMessage)
+                .foregroundColor(.red)
+                .multilineTextAlignment(.center)
+                .padding()
+        }
+    }
+}

--- a/ParrotIosTests/Mocks/Services/MockParrotApiService.swift
+++ b/ParrotIosTests/Mocks/Services/MockParrotApiService.swift
@@ -11,44 +11,51 @@ import Foundation
 
 struct ParrotApiServiceMethods {
     static let getLeaderboard = "getLeaderboard"
-    static let getWordOfTheDay = "getWordOfTheDay"
     static let getCurriculum = "getCurriculum"
     static let getExercise = "getExercise"
     static let postExerciseAttempt = "postExerciseAttempt"
+    static let getWordOfTheDay = "getWordOfTheDay"
+    static let postWordOfTheDayAttempt = "postWordOfTheDayAttempt"
 }
 
 class MockParrotApiService: ParrotApiServiceProtocol, CallTracking {
     var callCounts: [String : Int] = [:]
     var callArguments: [String : [[Any?]]] = [:]
     var returnValues: [String : [Result<Any?, any Error>]] = [:]
-    
+
     func getLeaderboard() async throws -> LeaderboardResponse {
         let method = ParrotApiServiceMethods.getLeaderboard
         recordCall(for: method)
         return try getReturnValue(for: method, callIndex: callCounts[method]! - 1)
     }
-    
-    func getWordOfTheDay() async throws -> ParrotIos.Word {
-        let method = ParrotApiServiceMethods.getWordOfTheDay
-        recordCall(for: method)
-        return try getReturnValue(for: method, callIndex: callCounts[method]! - 1)
-    }
-    
+
     func getCurriculum() async throws -> ParrotIos.Curriculum {
         let method = ParrotApiServiceMethods.getCurriculum
         recordCall(for: method)
         return try getReturnValue(for: method, callIndex: callCounts[method]! - 1)
     }
-    
+
     func getExercise(exerciseId: Int) async throws -> ParrotIos.Exercise {
         let method = ParrotApiServiceMethods.getExercise
         recordCall(for: method, with: [exerciseId])
         return try getReturnValue(for: method, callIndex: callCounts[method]! - 1)
     }
-    
+
     func postExerciseAttempt(recordingURL: URL, exercise: ParrotIos.Exercise) async throws -> ParrotIos.AttemptResponse {
         let method = ParrotApiServiceMethods.postExerciseAttempt
         recordCall(for: method, with: [recordingURL, exercise])
+        return try getReturnValue(for: method, callIndex: callCounts[method]! - 1)
+    }
+
+    func getWordOfTheDay() async throws -> ParrotIos.Word {
+        let method = ParrotApiServiceMethods.getWordOfTheDay
+        recordCall(for: method)
+        return try getReturnValue(for: method, callIndex: callCounts[method]! - 1)
+    }
+
+    func postWordOfTheDayAttempt(recordingURL: URL) async throws -> ParrotIos.AttemptResponse {
+        let method = ParrotApiServiceMethods.postExerciseAttempt
+        recordCall(for: method, with: [recordingURL])
         return try getReturnValue(for: method, callIndex: callCounts[method]! - 1)
     }
 }

--- a/ParrotIosTests/Mocks/Services/MockParrotApiService.swift
+++ b/ParrotIosTests/Mocks/Services/MockParrotApiService.swift
@@ -11,7 +11,7 @@ import Foundation
 
 struct ParrotApiServiceMethods {
     static let getLeaderboard = "getLeaderboard"
-    static let getRandomWord = "getRandomWord"
+    static let getWordOfTheDay = "getWordOfTheDay"
     static let getCurriculum = "getCurriculum"
     static let getExercise = "getExercise"
     static let postExerciseAttempt = "postExerciseAttempt"
@@ -28,8 +28,8 @@ class MockParrotApiService: ParrotApiServiceProtocol, CallTracking {
         return try getReturnValue(for: method, callIndex: callCounts[method]! - 1)
     }
     
-    func getRandomWord() async throws -> ParrotIos.Word {
-        let method = ParrotApiServiceMethods.getRandomWord
+    func getWordOfTheDay() async throws -> ParrotIos.Word {
+        let method = ParrotApiServiceMethods.getWordOfTheDay
         recordCall(for: method)
         return try getReturnValue(for: method, callIndex: callCounts[method]! - 1)
     }

--- a/ParrotIosTests/Services/ParrotApiServiceTest.swift
+++ b/ParrotIosTests/Services/ParrotApiServiceTest.swift
@@ -56,14 +56,14 @@ struct ParrotApiServiceTests {
     }
     
     @Test("Get random word returns success with valid response")
-    func testGetRandomWordSuccess() async throws {
+    func testGetWordOfTheDaySuccess() async throws {
         // Arrange
         mockAuthService.stub(method: AuthServiceMethods.getAccessToken, toReturn: testAccessToken)
         let expectedWord = Word(id: 1, text: "a", phonemes: [Phoneme(id: 1, ipa: "a", respelling: "a")])
         mockWebService.stub(method: WebServiceMethods.get, toReturn: expectedWord)
         
         // Act
-        let result = try await parrotApiService.getRandomWord()
+        let result = try await parrotApiService.getWordOfTheDay()
         
         // Assert
         #expect(result == expectedWord)

--- a/ParrotIosTests/Services/ParrotApiServiceTest.swift
+++ b/ParrotIosTests/Services/ParrotApiServiceTest.swift
@@ -54,8 +54,8 @@ struct ParrotApiServiceTests {
             _ = try await parrotApiService.getLeaderboard()
         }
     }
-    
-    @Test("Get random word returns success with valid response")
+
+    @Test("Get word of the day returns success with valid response")
     func testGetWordOfTheDaySuccess() async throws {
         // Arrange
         mockAuthService.stub(method: AuthServiceMethods.getAccessToken, toReturn: testAccessToken)
@@ -70,7 +70,7 @@ struct ParrotApiServiceTests {
         
         #expect(mockWebService.callCounts(for: WebServiceMethods.get) == 1)
         mockWebService.assertCallArguments(for: WebServiceMethods.get, matches: [
-            "\(parrotApiService.baseURL)/random_word",
+            "\(parrotApiService.baseURL)/word_of_day",
             [expectedAuthHeader]
         ])
     }


### PR DESCRIPTION
Blockers:
* word of the day post endpoint deployed on the backend

Features:
* a word of the day page, similar to an exercise view, with proper headers
* api get/post requests are ready, waiting for backend
* new navigation tab for wotd as the default view

Fixes and refactorings:
* disable recording button for 1 second after start of recording
* extract reusable subviews into a components directory
* remove random word endpoint

Skipped testing due to time constraints.