### PR TITLE
Fix audio synthesizer output

### DIFF
--- a/ParrotIos/Services/AudioSynthesizer.swift
+++ b/ParrotIos/Services/AudioSynthesizer.swift
@@ -20,6 +20,7 @@ class AudioSynthesizer: AudioSynthesizerProtocol {
             "por": "pt-BR"
         ]
         let synthesizerLanguage = languages[language] ?? "en-US"
+        try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .voicePrompt, options: [])
         let utterance = AVSpeechUtterance(string: word)
 
         let voices = AVSpeechSynthesisVoice.speechVoices()


### PR DESCRIPTION
Last PR, I thought audioSynthesizer uses audioPlayer and removed this line, turns out it doesn't. Added it back in so that audio comes out from main speaker.